### PR TITLE
Update link to old binaries to a Google Drive link

### DIFF
--- a/content/download/_index.html
+++ b/content/download/_index.html
@@ -71,5 +71,5 @@ If you're looking for binaries for a specific CPU architecture, <a href="/downlo
 <h2>Other Versions</h2>
 <ul class="small-block-grid-2">
     <li><a href="https://github.com/official-stockfish/Stockfish/releases?q=prerelease%3Atrue" class="" >Pre-release builds</a></li>
-    <li><a href="https://files.stockfishchess.org/archive/" class="" >Old (archived) releases of Stockfish</a></li>
+    <li><a href="https://drive.google.com/drive/folders/1nzrHOyZMFm4LATjF5ToRttCU0rHXGkXI?usp=share_link" class="" >Old (archived) releases of Stockfish</a></li>
 </ul>


### PR DESCRIPTION
Currently I pay for files.stockfishchess.org, whereas Google Drive is free